### PR TITLE
Add express auth backend

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,8 @@
+# Database connection string
+DATABASE_URL=postgresql://USERNAME:PASSWORD@HOST:PORT/DATABASE?sslmode=require
+
+# Secret key used to sign JWT tokens
+JWT_SECRET=changeme
+
+# Application port
+PORT=4000

--- a/.gitignore
+++ b/.gitignore
@@ -30,8 +30,10 @@ yarn-debug.log*
 yarn-error.log*
 .pnpm-debug.log*
 
-# env files (can opt-in for committing if needed)
-.env*
+# env files
+.env
+.env.*
+!*.example
 
 # vercel
 .vercel

--- a/README.md
+++ b/README.md
@@ -1,36 +1,30 @@
-This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
+# Budgetly
 
-## Getting Started
+This project contains a Next.js frontend and a small Express backend used for authentication.
 
-First, run the development server:
+## Backend Setup
+
+1. Copy `.env.example` to `.env` and fill in the variables. The `DATABASE_URL` should point to your PostgreSQL instance and `JWT_SECRET` is any random string.
+2. Install dependencies:
+   ```bash
+   npm install
+   ```
+3. Run migrations to create the database tables:
+   ```bash
+   npx sequelize-cli db:migrate
+   ```
+4. Start the API server:
+   ```bash
+   npm run server
+   ```
+   The API will be available at `http://localhost:4000`.
+
+## Frontend
+
+To start the Next.js development server run:
 
 ```bash
 npm run dev
-# or
-yarn dev
-# or
-pnpm dev
-# or
-bun dev
 ```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
-
-You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
-
-This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
-
-## Learn More
-
-To learn more about Next.js, take a look at the following resources:
-
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
-
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
-
-## Deploy on Vercel
-
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
-
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+The application will be available at `http://localhost:3000`.

--- a/package.json
+++ b/package.json
@@ -6,12 +6,20 @@
     "dev": "next dev --turbopack",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "server": "node server/app.js"
   },
   "dependencies": {
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "next": "15.2.4"
+    "next": "15.2.4",
+    "express": "^4.18.2",
+    "sequelize": "^6.37.1",
+    "pg": "^8.11.5",
+    "pg-hstore": "^2.3.4",
+    "bcrypt": "^5.1.1",
+    "jsonwebtoken": "^9.0.1",
+    "dotenv": "^16.4.5"
   },
   "devDependencies": {
     "typescript": "^5",
@@ -22,6 +30,7 @@
     "tailwindcss": "^4",
     "eslint": "^9",
     "eslint-config-next": "15.2.4",
-    "@eslint/eslintrc": "^3"
+    "@eslint/eslintrc": "^3",
+    "sequelize-cli": "^6.6.1"
   }
 }

--- a/server/.sequelizerc
+++ b/server/.sequelizerc
@@ -1,0 +1,7 @@
+const path = require('path');
+
+module.exports = {
+  config: path.resolve('server', 'config', 'database.js'),
+  'models-path': path.resolve('server', 'models'),
+  'migrations-path': path.resolve('server', 'migrations'),
+};

--- a/server/app.js
+++ b/server/app.js
@@ -1,0 +1,26 @@
+const express = require('express');
+const sequelize = require('./config/database');
+const authRoutes = require('./routes/authRoutes');
+require('dotenv').config();
+
+const app = express();
+app.use(express.json());
+
+app.use('/api', authRoutes); // Prefix routes with /api
+
+// Connect to the database and start the server
+async function start() {
+  try {
+    await sequelize.authenticate();
+    console.log('Database connected');
+    await sequelize.sync(); // Sync models (in production use migrations)
+    const port = process.env.PORT || 4000;
+    app.listen(port, () => console.log(`Server running on port ${port}`));
+  } catch (err) {
+    console.error('Failed to start server:', err);
+  }
+}
+
+start();
+
+module.exports = app;

--- a/server/config/database.js
+++ b/server/config/database.js
@@ -1,0 +1,10 @@
+const { Sequelize } = require('sequelize');
+require('dotenv').config();
+
+// Initialize Sequelize with the database URI from .env
+const sequelize = new Sequelize(process.env.DATABASE_URL, {
+  dialect: 'postgres',
+  logging: false,
+});
+
+module.exports = sequelize;

--- a/server/controllers/authController.js
+++ b/server/controllers/authController.js
@@ -1,0 +1,63 @@
+const bcrypt = require('bcrypt');
+const jwt = require('jsonwebtoken');
+const User = require('../models/user');
+
+// Helper to generate JWT token
+function generateToken(userId) {
+  return jwt.sign({ id: userId }, process.env.JWT_SECRET, {
+    expiresIn: '1h',
+  });
+}
+
+// POST /register controller
+exports.register = async (req, res) => {
+  const { name, email, password } = req.body;
+
+  // Basic validation of email and password
+  if (!email || !/^[^@]+@[^@]+\.[^@]+$/.test(email)) {
+    return res.status(400).json({ message: 'Invalid email' });
+  }
+  if (!password || password.length < 8) {
+    return res.status(400).json({ message: 'Password must be at least 8 characters' });
+  }
+
+  try {
+    // Check if the email is already registered
+    const existing = await User.findOne({ where: { email } });
+    if (existing) {
+      return res.status(409).json({ message: 'Email already registered' });
+    }
+
+    // Hash the password and create user
+    const hashed = await bcrypt.hash(password, 10);
+    const user = await User.create({ name, email, password: hashed });
+
+    return res.status(201).json({ id: user.id, name: user.name, email: user.email });
+  } catch (err) {
+    console.error(err);
+    return res.status(500).json({ message: 'Internal server error' });
+  }
+};
+
+// POST /login controller
+exports.login = async (req, res) => {
+  const { email, password } = req.body;
+
+  try {
+    const user = await User.findOne({ where: { email } });
+    if (!user) {
+      return res.status(401).json({ message: 'Invalid credentials' });
+    }
+
+    const valid = await bcrypt.compare(password, user.password);
+    if (!valid) {
+      return res.status(401).json({ message: 'Invalid credentials' });
+    }
+
+    const token = generateToken(user.id);
+    return res.json({ token });
+  } catch (err) {
+    console.error(err);
+    return res.status(500).json({ message: 'Internal server error' });
+  }
+};

--- a/server/migrations/20250606210000-create-user.js
+++ b/server/migrations/20250606210000-create-user.js
@@ -1,0 +1,42 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  // Create users table with required fields
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.createTable('users', {
+      id: {
+        type: Sequelize.UUID,
+        defaultValue: Sequelize.literal('uuid_generate_v4()'),
+        primaryKey: true,
+        allowNull: false,
+      },
+      name: {
+        type: Sequelize.STRING,
+        allowNull: false,
+      },
+      email: {
+        type: Sequelize.STRING,
+        allowNull: false,
+        unique: true,
+      },
+      password: {
+        type: Sequelize.STRING,
+        allowNull: false,
+      },
+      created_at: {
+        allowNull: false,
+        type: Sequelize.DATE,
+      },
+      updated_at: {
+        allowNull: false,
+        type: Sequelize.DATE,
+      },
+    });
+  },
+
+  // Drop users table
+  down: async (queryInterface) => {
+    await queryInterface.dropTable('users');
+  },
+};

--- a/server/models/user.js
+++ b/server/models/user.js
@@ -1,0 +1,32 @@
+const { DataTypes } = require('sequelize');
+const sequelize = require('../config/database');
+
+// Define the User model with fields and validations
+const User = sequelize.define('User', {
+  id: {
+    type: DataTypes.UUID,
+    defaultValue: DataTypes.UUIDV4,
+    primaryKey: true,
+  },
+  name: {
+    type: DataTypes.STRING,
+    allowNull: false,
+  },
+  email: {
+    type: DataTypes.STRING,
+    allowNull: false,
+    unique: true,
+    validate: {
+      isEmail: true, // Validates email format
+    },
+  },
+  password: {
+    type: DataTypes.STRING,
+    allowNull: false,
+  },
+}, {
+  underscored: true,
+  tableName: 'users',
+});
+
+module.exports = User;

--- a/server/routes/authRoutes.js
+++ b/server/routes/authRoutes.js
@@ -1,0 +1,9 @@
+const express = require('express');
+const router = express.Router();
+const authController = require('../controllers/authController');
+
+// Registration and login routes
+router.post('/register', authController.register);
+router.post('/login', authController.login);
+
+module.exports = router;


### PR DESCRIPTION
## Summary
- add express auth backend with sequelize
- track env example and allow env examples via gitignore
- document backend setup in README

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684354ce8874832b831fa701e8767885