### PR TITLE
Implement fixed expense registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,3 +41,16 @@ curl -X POST http://localhost:4000/api/incomes \
 ```
 
 Replace `YOUR_TOKEN` with the token returned by `/api/login`.
+
+## Registering a Fixed Expense
+
+Once authenticated you can create a recurring monthly expense:
+
+```bash
+curl -X POST http://localhost:4000/api/fixed-expenses \
+  -H "Authorization: Bearer YOUR_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"amount": 800.00, "description": "Rent", "due_date": "2024-01-05"}'
+```
+
+The `due_date` should be any valid day of the month (1-31) in `YYYY-MM-DD` format.

--- a/server/app.js
+++ b/server/app.js
@@ -2,6 +2,7 @@ const express = require('express');
 const sequelize = require('./config/database');
 const authRoutes = require('./routes/authRoutes');
 const incomeRoutes = require('./routes/incomeRoutes');
+const fixedExpenseRoutes = require('./routes/fixedExpenseRoutes');
 require('dotenv').config();
 
 const app = express();
@@ -9,6 +10,7 @@ app.use(express.json());
 
 app.use('/api', authRoutes); // Prefix routes with /api
 app.use('/api', incomeRoutes); // Routes for incomes
+app.use('/api', fixedExpenseRoutes); // Routes for fixed expenses
 
 // Connect to the database and start the server
 async function start() {

--- a/server/controllers/fixedExpenseController.js
+++ b/server/controllers/fixedExpenseController.js
@@ -1,0 +1,38 @@
+const FixedExpense = require('../models/fixedExpense');
+
+// POST /fixed-expenses - create a new fixed expense for the authenticated user
+exports.createFixedExpense = async (req, res) => {
+  const { amount, description, due_date } = req.body;
+
+  // Validate amount is a positive number
+  if (amount === undefined || isNaN(amount) || Number(amount) <= 0) {
+    return res.status(400).json({ message: 'Amount must be a positive number' });
+  }
+
+  // Validate due_date format YYYY-MM-DD and day of month 1-31
+  if (!due_date || !/^\d{4}-\d{2}-\d{2}$/.test(due_date)) {
+    return res.status(400).json({ message: 'Invalid due_date format. Use YYYY-MM-DD' });
+  }
+  const day = Number(due_date.split('-')[2]);
+  if (day < 1 || day > 31) {
+    return res.status(400).json({ message: 'Invalid due date day' });
+  }
+
+  // Validate description length if provided
+  if (description && description.length > 255) {
+    return res.status(400).json({ message: 'Description too long' });
+  }
+
+  try {
+    const fixedExpense = await FixedExpense.create({
+      user_id: req.userId,
+      amount,
+      description,
+      due_date,
+    });
+    return res.status(201).json(fixedExpense);
+  } catch (err) {
+    console.error(err);
+    return res.status(500).json({ message: 'Failed to create fixed expense' });
+  }
+};

--- a/server/migrations/20250606212000-create-fixed-expense.js
+++ b/server/migrations/20250606212000-create-fixed-expense.js
@@ -1,0 +1,50 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  // Create fixed_expenses table with required fields and references
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.createTable('fixed_expenses', {
+      id: {
+        type: Sequelize.UUID,
+        defaultValue: Sequelize.literal('uuid_generate_v4()'),
+        primaryKey: true,
+        allowNull: false,
+      },
+      user_id: {
+        type: Sequelize.UUID,
+        allowNull: false,
+        references: {
+          model: 'users',
+          key: 'id',
+        },
+        onDelete: 'CASCADE',
+      },
+      amount: {
+        type: Sequelize.DECIMAL(10, 2),
+        allowNull: false,
+      },
+      description: {
+        type: Sequelize.STRING(255),
+        allowNull: true,
+      },
+      due_date: {
+        type: Sequelize.DATEONLY,
+        allowNull: false,
+      },
+      created_at: {
+        allowNull: false,
+        type: Sequelize.DATE,
+      },
+      updated_at: {
+        allowNull: false,
+        type: Sequelize.DATE,
+      },
+    });
+  },
+
+  // Drop fixed_expenses table
+  down: async (queryInterface) => {
+    await queryInterface.dropTable('fixed_expenses');
+  },
+};

--- a/server/models/fixedExpense.js
+++ b/server/models/fixedExpense.js
@@ -1,0 +1,40 @@
+const { DataTypes } = require('sequelize');
+const sequelize = require('../config/database');
+const User = require('./user');
+
+// Define the FixedExpense model with fields and associations
+const FixedExpense = sequelize.define('FixedExpense', {
+  id: {
+    type: DataTypes.UUID,
+    defaultValue: DataTypes.UUIDV4,
+    primaryKey: true,
+  },
+  user_id: {
+    type: DataTypes.UUID,
+    allowNull: false,
+  },
+  amount: {
+    type: DataTypes.DECIMAL(10, 2),
+    allowNull: false,
+    validate: {
+      min: 0,
+    },
+  },
+  description: {
+    type: DataTypes.STRING(255),
+    allowNull: true,
+  },
+  due_date: {
+    type: DataTypes.DATEONLY,
+    allowNull: false,
+  },
+}, {
+  underscored: true,
+  tableName: 'fixed_expenses',
+});
+
+// Associate fixed expense to user
+FixedExpense.belongsTo(User, { foreignKey: 'user_id' });
+User.hasMany(FixedExpense, { foreignKey: 'user_id' });
+
+module.exports = FixedExpense;

--- a/server/routes/fixedExpenseRoutes.js
+++ b/server/routes/fixedExpenseRoutes.js
@@ -1,0 +1,9 @@
+const express = require('express');
+const router = express.Router();
+const fixedExpenseController = require('../controllers/fixedExpenseController');
+const auth = require('../middlewares/authMiddleware');
+
+// Protected route to create a new fixed expense
+router.post('/fixed-expenses', auth, fixedExpenseController.createFixedExpense);
+
+module.exports = router;


### PR DESCRIPTION
## Summary
- implement FixedExpense model
- add migration for fixed_expenses table
- create controller and routes for fixed expenses
- register fixed expense routes in the server
- document how to register a fixed expense

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68436391dc2c832b8818c782b67a833a