### PR TITLE
Add auth pages and monthly budget view

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,8 @@ import type React from "react"
 import type { Metadata } from "next"
 import { Inter } from "next/font/google"
 import "./globals.css"
+import { AuthProvider } from "@/lib/auth-context"
+import { Navbar } from "@/components/navbar"
 
 const inter = Inter({ subsets: ["latin"] })
 
@@ -18,7 +20,12 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en">
-      <body className={inter.className}>{children}</body>
+      <body className={inter.className}>
+        <AuthProvider>
+          <Navbar />
+          {children}
+        </AuthProvider>
+      </body>
     </html>
   )
 }

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,0 +1,41 @@
+"use client"
+
+import { useState } from "react"
+import { useRouter } from "next/navigation"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Button } from "@/components/ui/button"
+import Link from "next/link"
+import { useAuth } from "@/lib/auth-context"
+
+export default function LoginPage() {
+  const [email, setEmail] = useState("")
+  const [password, setPassword] = useState("")
+  const { login } = useAuth()
+  const router = useRouter()
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault()
+    login(email)
+    router.push("/")
+  }
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-slate-50 to-slate-100 p-4">
+      <form onSubmit={handleSubmit} className="space-y-6 max-w-sm w-full bg-white p-6 rounded-lg shadow">
+        <div className="space-y-2">
+          <Label htmlFor="email">Email</Label>
+          <Input id="email" type="email" value={email} onChange={(e) => setEmail(e.target.value)} required />
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="password">Password</Label>
+          <Input id="password" type="password" value={password} onChange={(e) => setPassword(e.target.value)} required />
+        </div>
+        <Button type="submit" className="w-full">Log In</Button>
+        <p className="text-center text-sm text-muted-foreground">
+          Don't have an account? <Link href="/signup" className="underline">Sign Up</Link>
+        </p>
+      </form>
+    </div>
+  )
+}

--- a/src/app/monthly-budget/page.tsx
+++ b/src/app/monthly-budget/page.tsx
@@ -1,0 +1,31 @@
+import { Suspense } from "react"
+import { MonthNavigation } from "@/components/month-navigation"
+import { FinancialSummary } from "@/components/financial-summary"
+import { ExpenseChart } from "@/components/expense-chart"
+import { getCurrentMonth, getMonthData } from "@/lib/finance-data"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+
+export default function MonthlyBudgetPage() {
+  const currentMonth = getCurrentMonth()
+  const monthData = getMonthData(currentMonth)
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-slate-50 to-slate-100 p-4">
+      <div className="max-w-7xl mx-auto space-y-6">
+        <h1 className="text-3xl font-bold text-slate-900">Monthly Budget</h1>
+        <MonthNavigation currentMonth={currentMonth} />
+        <FinancialSummary data={monthData} />
+        <Card>
+          <CardHeader>
+            <CardTitle>Expense Breakdown</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <Suspense fallback={<div className="h-64 bg-slate-100 animate-pulse rounded" />}>
+              <ExpenseChart data={monthData} />
+            </Suspense>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  )
+}

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -1,0 +1,41 @@
+"use client"
+
+import { useState } from "react"
+import { useRouter } from "next/navigation"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Button } from "@/components/ui/button"
+import Link from "next/link"
+import { useAuth } from "@/lib/auth-context"
+
+export default function SignupPage() {
+  const [email, setEmail] = useState("")
+  const [password, setPassword] = useState("")
+  const { signup } = useAuth()
+  const router = useRouter()
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault()
+    signup(email)
+    router.push("/")
+  }
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-slate-50 to-slate-100 p-4">
+      <form onSubmit={handleSubmit} className="space-y-6 max-w-sm w-full bg-white p-6 rounded-lg shadow">
+        <div className="space-y-2">
+          <Label htmlFor="email">Email</Label>
+          <Input id="email" type="email" value={email} onChange={(e) => setEmail(e.target.value)} required />
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="password">Password</Label>
+          <Input id="password" type="password" value={password} onChange={(e) => setPassword(e.target.value)} required />
+        </div>
+        <Button type="submit" className="w-full">Sign Up</Button>
+        <p className="text-center text-sm text-muted-foreground">
+          Already have an account? <Link href="/login" className="underline">Log In</Link>
+        </p>
+      </form>
+    </div>
+  )
+}

--- a/src/components/expense-chart.tsx
+++ b/src/components/expense-chart.tsx
@@ -11,7 +11,9 @@ export function ExpenseChart({ data }: ExpenseChartProps) {
     .filter((t) => t.type !== "income")
     .reduce(
       (acc, transaction) => {
-        acc[transaction.category] = (acc[transaction.category] || 0) + transaction.amount
+        acc[transaction.category] =
+          (acc[transaction.category] || 0) + transaction.amount
+        return acc
       },
       {} as Record<string, number>,
     )

--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -1,0 +1,37 @@
+"use client"
+
+import Link from "next/link"
+import { Button } from "@/components/ui/button"
+import { useAuth } from "@/lib/auth-context"
+
+export function Navbar() {
+  const { user, logout } = useAuth()
+  return (
+    <header className="bg-white shadow-sm">
+      <div className="max-w-7xl mx-auto px-4 py-3 flex justify-between items-center">
+        <Link href="/" className="font-bold text-lg">
+          Budgetly
+        </Link>
+        <nav className="flex items-center gap-2">
+          {user ? (
+            <>
+              <span className="text-sm text-slate-600">Hello, {user}</span>
+              <Button variant="outline" onClick={logout}>
+                Logout
+              </Button>
+            </>
+          ) : (
+            <>
+              <Link href="/login">
+                <Button variant="ghost">Login</Button>
+              </Link>
+              <Link href="/signup">
+                <Button>Sign Up</Button>
+              </Link>
+            </>
+          )}
+        </nav>
+      </div>
+    </header>
+  )
+}

--- a/src/lib/auth-context.tsx
+++ b/src/lib/auth-context.tsx
@@ -1,0 +1,51 @@
+"use client"
+
+import React, { createContext, useContext, useEffect, useState } from "react"
+
+interface AuthState {
+  user: string | null
+  login: (email: string) => void
+  signup: (email: string) => void
+  logout: () => void
+}
+
+const AuthContext = createContext<AuthState | undefined>(undefined)
+
+export function AuthProvider({ children }: { children: React.ReactNode }) {
+  const [user, setUser] = useState<string | null>(null)
+
+  useEffect(() => {
+    const stored = typeof window !== "undefined" ? localStorage.getItem("user") : null
+    if (stored) setUser(stored)
+  }, [])
+
+  const login = (email: string) => {
+    setUser(email)
+    if (typeof window !== "undefined") {
+      localStorage.setItem("user", email)
+    }
+  }
+
+  const signup = login
+
+  const logout = () => {
+    setUser(null)
+    if (typeof window !== "undefined") {
+      localStorage.removeItem("user")
+    }
+  }
+
+  return (
+    <AuthContext.Provider value={{ user, login, signup, logout }}>
+      {children}
+    </AuthContext.Provider>
+  )
+}
+
+export function useAuth() {
+  const ctx = useContext(AuthContext)
+  if (!ctx) {
+    throw new Error("useAuth must be used within AuthProvider")
+  }
+  return ctx
+}


### PR DESCRIPTION
## Summary
- integrate simple auth context and navbar
- add login and signup pages
- add monthly budget screen
- show navbar in layout

## Testing
- `npm run lint` *(fails: `next: not found`)*
- `npm run build` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6843b4dd5860832bb1d9e00266421665