### PR TITLE
Fix useSearchParams error in monthly-budget page

### DIFF
--- a/src/app/monthly-budget/page.tsx
+++ b/src/app/monthly-budget/page.tsx
@@ -13,7 +13,9 @@ export default function MonthlyBudgetPage() {
     <div className="min-h-screen bg-gradient-to-br from-slate-50 to-slate-100 p-4">
       <div className="max-w-7xl mx-auto space-y-6">
         <h1 className="text-3xl font-bold text-slate-900">Monthly Budget</h1>
-        <MonthNavigation currentMonth={currentMonth} />
+          <Suspense fallback={<div>Loading...</div>}>
+            <MonthNavigation currentMonth={currentMonth} />
+          </Suspense>
         <FinancialSummary data={monthData} />
         <Card>
           <CardHeader>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -30,8 +30,10 @@ export default function Dashboard() {
           </Link>
         </div>
 
-        {/* Month Navigation */}
-        <MonthNavigation currentMonth={currentMonth} />
+          {/* Month Navigation */}
+          <Suspense fallback={<div>Loading...</div>}>
+            <MonthNavigation currentMonth={currentMonth} />
+          </Suspense>
 
         {/* Financial Summary Cards */}
         <FinancialSummary data={monthData} />

--- a/src/app/transactions/page.tsx
+++ b/src/app/transactions/page.tsx
@@ -2,6 +2,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
 import { ArrowLeft, Plus } from "lucide-react"
 import Link from "next/link"
+import { Suspense } from "react"
 import { TransactionList } from "@/components/transaction-list"
 import { MonthNavigation } from "@/components/month-navigation"
 import { getCurrentMonth, getMonthData } from "@/lib/finance-data"
@@ -35,7 +36,9 @@ export default function TransactionsPage() {
         </div>
 
         {/* Month Navigation */}
-        <MonthNavigation currentMonth={currentMonth} />
+        <Suspense fallback={<div>Loading...</div>}>
+          <MonthNavigation currentMonth={currentMonth} />
+        </Suspense>
 
         {/* Transactions */}
         <Card>


### PR DESCRIPTION
## Summary
- wrap MonthNavigation in `<Suspense>` on transactions page, monthly budget, and home

## Testing
- `npm install` *(fails: MaxListenersExceededWarning)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843bbb35ab4832ba7204760425f69f9