### PR TITLE
Translate recent transaction tags and types

### DIFF
--- a/src/app/add-transaction/AddTransactionForm.tsx
+++ b/src/app/add-transaction/AddTransactionForm.tsx
@@ -14,11 +14,13 @@ import { ArrowLeft, Save } from "lucide-react"
 import Link from "next/link"
 import { addTransaction } from "@/lib/finance-data"
 import type { TransactionType } from "@/lib/types"
+import { useI18n } from "@/lib/i18n-context"
 
 export default function AddTransactionForm() {
   const router = useRouter()
   const searchParams = useSearchParams()
   const defaultType = (searchParams.get("type") as TransactionType) || "variable"
+  const { t } = useI18n()
 
   const [formData, setFormData] = useState({
     type: defaultType,
@@ -48,7 +50,7 @@ export default function AddTransactionForm() {
     router.push("/")
   }
 
-  const categories = {
+  const categoryKeys = {
     income: ["Salary", "Freelance", "Investment", "Other"],
     fixed: ["Rent", "Insurance", "Loan Payment", "Subscription", "Utilities"],
     variable: ["Food", "Transportation", "Entertainment", "Shopping", "Healthcare", "Other"],
@@ -65,21 +67,21 @@ export default function AddTransactionForm() {
             </Button>
           </Link>
           <div>
-            <h1 className="text-2xl font-bold text-slate-900">Add Transaction</h1>
-            <p className="text-slate-600">Record a new financial transaction</p>
+            <h1 className="text-2xl font-bold text-slate-900">{t("addTransaction.headerTitle")}</h1>
+            <p className="text-slate-600">{t("addTransaction.headerSubtitle")}</p>
           </div>
         </div>
 
         {/* Form */}
         <Card>
           <CardHeader>
-            <CardTitle>Transaction Details</CardTitle>
+            <CardTitle>{t("addTransaction.details")}</CardTitle>
           </CardHeader>
           <CardContent>
             <form onSubmit={handleSubmit} className="space-y-6">
               {/* Transaction Type */}
               <div className="space-y-2">
-                <Label htmlFor="type">Transaction Type</Label>
+                <Label htmlFor="type">{t("addTransaction.type")}</Label>
                 <Select
                   value={formData.type}
                   onValueChange={(value: TransactionType) => setFormData({ ...formData, type: value, category: "" })}
@@ -88,16 +90,16 @@ export default function AddTransactionForm() {
                     <SelectValue />
                   </SelectTrigger>
                   <SelectContent>
-                    <SelectItem value="income">Income</SelectItem>
-                    <SelectItem value="fixed">Fixed Expense</SelectItem>
-                    <SelectItem value="variable">Variable Expense</SelectItem>
+                    <SelectItem value="income">{t("addTransaction.income")}</SelectItem>
+                    <SelectItem value="fixed">{t("addTransaction.fixedExpense")}</SelectItem>
+                    <SelectItem value="variable">{t("addTransaction.variableExpense")}</SelectItem>
                   </SelectContent>
                 </Select>
               </div>
 
               {/* Amount */}
               <div className="space-y-2">
-                <Label htmlFor="amount">Amount ($)</Label>
+                <Label htmlFor="amount">{t("addTransaction.amount")}</Label>
                 <Input
                   id="amount"
                   type="number"
@@ -111,30 +113,30 @@ export default function AddTransactionForm() {
 
               {/* Description */}
               <div className="space-y-2">
-                <Label htmlFor="description">Description</Label>
+                <Label htmlFor="description">{t("addTransaction.description")}</Label>
                 <Textarea
                   id="description"
                   value={formData.description}
                   onChange={(e) => setFormData({ ...formData, description: e.target.value })}
-                  placeholder="Enter transaction description"
+                  placeholder={t("addTransaction.enterDescription")}
                   required
                 />
               </div>
 
               {/* Category */}
               <div className="space-y-2">
-                <Label htmlFor="category">Category</Label>
+                <Label htmlFor="category">{t("addTransaction.category")}</Label>
                 <Select
                   value={formData.category}
                   onValueChange={(value) => setFormData({ ...formData, category: value })}
                 >
                   <SelectTrigger>
-                    <SelectValue placeholder="Select a category" />
+                    <SelectValue placeholder={t("addTransaction.selectCategory")} />
                   </SelectTrigger>
                   <SelectContent>
-                    {categories[formData.type].map((category) => (
+                    {categoryKeys[formData.type].map((category) => (
                       <SelectItem key={category} value={category}>
-                        {category}
+                        {t(`category.${category}`)}
                       </SelectItem>
                     ))}
                   </SelectContent>
@@ -143,7 +145,7 @@ export default function AddTransactionForm() {
 
               {/* Date */}
               <div className="space-y-2">
-                <Label htmlFor="date">Date</Label>
+                <Label htmlFor="date">{t("addTransaction.date")}</Label>
                 <Input
                   id="date"
                   type="date"
@@ -157,7 +159,7 @@ export default function AddTransactionForm() {
               {formData.type === "fixed" && (
                 <div className="space-y-4 p-4 bg-slate-50 rounded-lg">
                   <div className="flex items-center justify-between">
-                    <Label htmlFor="recurring">Recurring Transaction</Label>
+                    <Label htmlFor="recurring">{t("addTransaction.recurringTransaction")}</Label>
                     <Switch
                       id="recurring"
                       checked={formData.isRecurring}
@@ -167,7 +169,7 @@ export default function AddTransactionForm() {
 
                   {formData.isRecurring && (
                     <div className="space-y-2">
-                      <Label htmlFor="recurringMonths">Number of Months</Label>
+                      <Label htmlFor="recurringMonths">{t("addTransaction.numberOfMonths")}</Label>
                       <Input
                         id="recurringMonths"
                         type="number"
@@ -184,7 +186,7 @@ export default function AddTransactionForm() {
               {/* Submit Button */}
               <Button type="submit" className="w-full flex items-center gap-2">
                 <Save className="w-4 h-4" />
-                Save Transaction
+                {t("addTransaction.save")}
               </Button>
             </form>
           </CardContent>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,7 @@ import type { Metadata } from "next"
 import { Inter } from "next/font/google"
 import "./globals.css"
 import { AuthProvider } from "@/lib/auth-context"
+import { I18nProvider } from "@/lib/i18n-context"
 import { Navbar } from "@/components/navbar"
 
 const inter = Inter({ subsets: ["latin"] })
@@ -21,10 +22,12 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className={inter.className}>
-        <AuthProvider>
-          <Navbar />
-          {children}
-        </AuthProvider>
+        <I18nProvider>
+          <AuthProvider>
+            <Navbar />
+            {children}
+          </AuthProvider>
+        </I18nProvider>
       </body>
     </html>
   )

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -7,12 +7,14 @@ import { Label } from "@/components/ui/label"
 import { Button } from "@/components/ui/button"
 import Link from "next/link"
 import { useAuth } from "@/lib/auth-context"
+import { useI18n } from "@/lib/i18n-context"
 
 export default function LoginPage() {
   const [email, setEmail] = useState("")
   const [password, setPassword] = useState("")
   const { login } = useAuth()
   const router = useRouter()
+  const { t } = useI18n()
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault()
@@ -24,16 +26,16 @@ export default function LoginPage() {
     <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-slate-50 to-slate-100 p-4">
       <form onSubmit={handleSubmit} className="space-y-6 max-w-sm w-full bg-white p-6 rounded-lg shadow">
         <div className="space-y-2">
-          <Label htmlFor="email">Email</Label>
+          <Label htmlFor="email">{t("login.email")}</Label>
           <Input id="email" type="email" value={email} onChange={(e) => setEmail(e.target.value)} required />
         </div>
         <div className="space-y-2">
-          <Label htmlFor="password">Password</Label>
+          <Label htmlFor="password">{t("login.password")}</Label>
           <Input id="password" type="password" value={password} onChange={(e) => setPassword(e.target.value)} required />
         </div>
-        <Button type="submit" className="w-full">Log In</Button>
+        <Button type="submit" className="w-full">{t("login.logIn")}</Button>
         <p className="text-center text-sm text-muted-foreground">
-          Don't have an account? <Link href="/signup" className="underline">Sign Up</Link>
+          {t("login.noAccount")} <Link href="/signup" className="underline">{t("login.signUp")}</Link>
         </p>
       </form>
     </div>

--- a/src/app/monthly-budget/page.tsx
+++ b/src/app/monthly-budget/page.tsx
@@ -1,25 +1,29 @@
+"use client"
+
 import { Suspense } from "react"
 import { MonthNavigation } from "@/components/month-navigation"
 import { FinancialSummary } from "@/components/financial-summary"
 import { ExpenseChart } from "@/components/expense-chart"
 import { getCurrentMonth, getMonthData } from "@/lib/finance-data"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { useI18n } from "@/lib/i18n-context"
 
 export default function MonthlyBudgetPage() {
+  const { t } = useI18n()
   const currentMonth = getCurrentMonth()
   const monthData = getMonthData(currentMonth)
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-slate-50 to-slate-100 p-4">
       <div className="max-w-7xl mx-auto space-y-6">
-        <h1 className="text-3xl font-bold text-slate-900">Monthly Budget</h1>
-          <Suspense fallback={<div>Loading...</div>}>
+        <h1 className="text-3xl font-bold text-slate-900">{t("monthlyBudgetPage.title")}</h1>
+          <Suspense fallback={<div>{t("common.loading")}</div>}>
             <MonthNavigation currentMonth={currentMonth} />
           </Suspense>
         <FinancialSummary data={monthData} />
         <Card>
           <CardHeader>
-            <CardTitle>Expense Breakdown</CardTitle>
+            <CardTitle>{t("dashboard.expenseBreakdown")}</CardTitle>
           </CardHeader>
           <CardContent>
             <Suspense fallback={<div className="h-64 bg-slate-100 animate-pulse rounded" />}>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,3 +1,5 @@
+"use client"
+
 import { Suspense } from "react"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
@@ -8,8 +10,10 @@ import { FinancialSummary } from "@/components/financial-summary"
 import { RecentTransactions } from "@/components/recent-transactions"
 import { ExpenseChart } from "@/components/expense-chart"
 import { getCurrentMonth, getMonthData } from "@/lib/finance-data"
+import { useI18n } from "@/lib/i18n-context"
 
 export default function Dashboard() {
+  const { t } = useI18n()
   const currentMonth = getCurrentMonth()
   const monthData = getMonthData(currentMonth)
 
@@ -19,19 +23,19 @@ export default function Dashboard() {
         {/* Header */}
         <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4">
           <div>
-            <h1 className="text-3xl font-bold text-slate-900">Finance Tracker</h1>
-            <p className="text-slate-600">Manage your monthly finances with ease</p>
+            <h1 className="text-3xl font-bold text-slate-900">{t("dashboard.title")}</h1>
+            <p className="text-slate-600">{t("dashboard.subtitle")}</p>
           </div>
           <Link href="/add-transaction">
             <Button className="flex items-center gap-2">
               <Plus className="w-4 h-4" />
-              Add Transaction
+              {t("dashboard.addTransaction")}
             </Button>
           </Link>
         </div>
 
           {/* Month Navigation */}
-          <Suspense fallback={<div>Loading...</div>}>
+          <Suspense fallback={<div>{t("common.loading")}</div>}>
             <MonthNavigation currentMonth={currentMonth} />
           </Suspense>
 
@@ -44,7 +48,7 @@ export default function Dashboard() {
             <CardHeader>
               <CardTitle className="flex items-center gap-2">
                 <TrendingUp className="w-5 h-5" />
-                Expense Breakdown
+                {t("dashboard.expenseBreakdown")}
               </CardTitle>
             </CardHeader>
             <CardContent>
@@ -58,7 +62,7 @@ export default function Dashboard() {
             <CardHeader>
               <CardTitle className="flex items-center gap-2">
                 <Calendar className="w-5 h-5" />
-                Recent Transactions
+                {t("dashboard.recentTransactions")}
               </CardTitle>
             </CardHeader>
             <CardContent>
@@ -70,26 +74,26 @@ export default function Dashboard() {
         {/* Quick Actions */}
         <Card>
           <CardHeader>
-            <CardTitle>Quick Actions</CardTitle>
+            <CardTitle>{t("dashboard.quickActions")}</CardTitle>
           </CardHeader>
           <CardContent>
             <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
               <Link href="/add-transaction?type=income">
                 <Button variant="outline" className="w-full h-20 flex flex-col gap-2">
                   <TrendingUp className="w-6 h-6 text-green-600" />
-                  Add Income
+                  {t("dashboard.addIncome")}
                 </Button>
               </Link>
               <Link href="/add-transaction?type=fixed">
                 <Button variant="outline" className="w-full h-20 flex flex-col gap-2">
                   <DollarSign className="w-6 h-6 text-blue-600" />
-                  Add Fixed Expense
+                  {t("dashboard.addFixedExpense")}
                 </Button>
               </Link>
               <Link href="/add-transaction?type=variable">
                 <Button variant="outline" className="w-full h-20 flex flex-col gap-2">
                   <TrendingDown className="w-6 h-6 text-red-600" />
-                  Add Variable Expense
+                  {t("dashboard.addVariableExpense")}
                 </Button>
               </Link>
             </div>

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -7,12 +7,14 @@ import { Label } from "@/components/ui/label"
 import { Button } from "@/components/ui/button"
 import Link from "next/link"
 import { useAuth } from "@/lib/auth-context"
+import { useI18n } from "@/lib/i18n-context"
 
 export default function SignupPage() {
   const [email, setEmail] = useState("")
   const [password, setPassword] = useState("")
   const { signup } = useAuth()
   const router = useRouter()
+  const { t } = useI18n()
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault()
@@ -24,16 +26,16 @@ export default function SignupPage() {
     <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-slate-50 to-slate-100 p-4">
       <form onSubmit={handleSubmit} className="space-y-6 max-w-sm w-full bg-white p-6 rounded-lg shadow">
         <div className="space-y-2">
-          <Label htmlFor="email">Email</Label>
+          <Label htmlFor="email">{t("login.email")}</Label>
           <Input id="email" type="email" value={email} onChange={(e) => setEmail(e.target.value)} required />
         </div>
         <div className="space-y-2">
-          <Label htmlFor="password">Password</Label>
+          <Label htmlFor="password">{t("login.password")}</Label>
           <Input id="password" type="password" value={password} onChange={(e) => setPassword(e.target.value)} required />
         </div>
-        <Button type="submit" className="w-full">Sign Up</Button>
+        <Button type="submit" className="w-full">{t("signup.signUp")}</Button>
         <p className="text-center text-sm text-muted-foreground">
-          Already have an account? <Link href="/login" className="underline">Log In</Link>
+          {t("signup.haveAccount")} <Link href="/login" className="underline">{t("signup.logIn")}</Link>
         </p>
       </form>
     </div>

--- a/src/app/transactions/page.tsx
+++ b/src/app/transactions/page.tsx
@@ -1,3 +1,5 @@
+"use client"
+
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
 import { ArrowLeft, Plus } from "lucide-react"
@@ -6,8 +8,10 @@ import { Suspense } from "react"
 import { TransactionList } from "@/components/transaction-list"
 import { MonthNavigation } from "@/components/month-navigation"
 import { getCurrentMonth, getMonthData } from "@/lib/finance-data"
+import { useI18n } from "@/lib/i18n-context"
 
 export default function TransactionsPage() {
+  const { t } = useI18n()
   const currentMonth = getCurrentMonth()
   const monthData = getMonthData(currentMonth)
 
@@ -23,27 +27,27 @@ export default function TransactionsPage() {
               </Button>
             </Link>
             <div>
-              <h1 className="text-2xl font-bold text-slate-900">All Transactions</h1>
-              <p className="text-slate-600">View and manage your transactions</p>
+              <h1 className="text-2xl font-bold text-slate-900">{t("transactionsPage.allTransactions")}</h1>
+              <p className="text-slate-600">{t("transactionsPage.viewManage")}</p>
             </div>
           </div>
           <Link href="/add-transaction">
             <Button className="flex items-center gap-2">
               <Plus className="w-4 h-4" />
-              Add Transaction
+              {t("dashboard.addTransaction")}
             </Button>
           </Link>
         </div>
 
         {/* Month Navigation */}
-        <Suspense fallback={<div>Loading...</div>}>
+        <Suspense fallback={<div>{t("common.loading")}</div>}>
           <MonthNavigation currentMonth={currentMonth} />
         </Suspense>
 
         {/* Transactions */}
         <Card>
           <CardHeader>
-            <CardTitle>Transactions for {currentMonth}</CardTitle>
+            <CardTitle>{t("transactionsPage.transactionsFor")} {currentMonth}</CardTitle>
           </CardHeader>
           <CardContent>
             <TransactionList transactions={monthData.transactions} />

--- a/src/components/expense-chart.tsx
+++ b/src/components/expense-chart.tsx
@@ -1,12 +1,14 @@
 "use client"
 
 import type { MonthData } from "@/lib/types"
+import { useI18n } from "@/lib/i18n-context"
 
 interface ExpenseChartProps {
   data: MonthData
 }
 
 export function ExpenseChart({ data }: ExpenseChartProps) {
+  const { t, lang } = useI18n()
   const categoryTotals = data.transactions
     .filter((t) => t.type !== "income")
     .reduce(
@@ -21,7 +23,8 @@ export function ExpenseChart({ data }: ExpenseChartProps) {
   const totalExpenses = Object.values(categoryTotals).reduce((sum, amount) => sum + amount, 0)
 
   const formatCurrency = (amount: number) => {
-    return new Intl.NumberFormat("en-US", {
+    const locale = lang === "pt" ? "pt-BR" : lang === "es" ? "es-ES" : "en-US"
+    return new Intl.NumberFormat(locale, {
       style: "currency",
       currency: "USD",
     }).format(amount)
@@ -39,7 +42,7 @@ export function ExpenseChart({ data }: ExpenseChartProps) {
   ]
 
   if (totalExpenses === 0) {
-    return <div className="text-center py-8 text-slate-500">No expenses recorded yet.</div>
+    return <div className="text-center py-8 text-slate-500">{t("expenseChart.noExpenses")}</div>
   }
 
   return (

--- a/src/components/financial-summary.tsx
+++ b/src/components/financial-summary.tsx
@@ -1,12 +1,16 @@
+"use client"
+
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { TrendingUp, TrendingDown, DollarSign, PiggyBank } from "lucide-react"
 import type { MonthData } from "@/lib/types"
+import { useI18n } from "@/lib/i18n-context"
 
 interface FinancialSummaryProps {
   data: MonthData
 }
 
 export function FinancialSummary({ data }: FinancialSummaryProps) {
+  const { t, lang } = useI18n()
   const totalIncome = data.transactions.filter((t) => t.type === "income").reduce((sum, t) => sum + t.amount, 0)
 
   const totalFixedExpenses = data.transactions.filter((t) => t.type === "fixed").reduce((sum, t) => sum + t.amount, 0)
@@ -19,7 +23,9 @@ export function FinancialSummary({ data }: FinancialSummaryProps) {
   const netIncome = totalIncome - totalExpenses
 
   const formatCurrency = (amount: number) => {
-    return new Intl.NumberFormat("en-US", {
+    const locale =
+      lang === "pt" ? "pt-BR" : lang === "es" ? "es-ES" : "en-US"
+    return new Intl.NumberFormat(locale, {
       style: "currency",
       currency: "USD",
     }).format(amount)
@@ -29,7 +35,7 @@ export function FinancialSummary({ data }: FinancialSummaryProps) {
     <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
       <Card>
         <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-          <CardTitle className="text-sm font-medium">Total Income</CardTitle>
+          <CardTitle className="text-sm font-medium">{t("financialSummary.totalIncome")}</CardTitle>
           <TrendingUp className="h-4 w-4 text-green-600" />
         </CardHeader>
         <CardContent>
@@ -39,7 +45,7 @@ export function FinancialSummary({ data }: FinancialSummaryProps) {
 
       <Card>
         <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-          <CardTitle className="text-sm font-medium">Fixed Expenses</CardTitle>
+          <CardTitle className="text-sm font-medium">{t("financialSummary.fixedExpenses")}</CardTitle>
           <DollarSign className="h-4 w-4 text-blue-600" />
         </CardHeader>
         <CardContent>
@@ -49,7 +55,7 @@ export function FinancialSummary({ data }: FinancialSummaryProps) {
 
       <Card>
         <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-          <CardTitle className="text-sm font-medium">Variable Expenses</CardTitle>
+          <CardTitle className="text-sm font-medium">{t("financialSummary.variableExpenses")}</CardTitle>
           <TrendingDown className="h-4 w-4 text-red-600" />
         </CardHeader>
         <CardContent>
@@ -59,7 +65,7 @@ export function FinancialSummary({ data }: FinancialSummaryProps) {
 
       <Card>
         <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-          <CardTitle className="text-sm font-medium">Net Income</CardTitle>
+          <CardTitle className="text-sm font-medium">{t("financialSummary.netIncome")}</CardTitle>
           <PiggyBank className={`h-4 w-4 ${netIncome >= 0 ? "text-green-600" : "text-red-600"}`} />
         </CardHeader>
         <CardContent>

--- a/src/components/language-selector.tsx
+++ b/src/components/language-selector.tsx
@@ -1,0 +1,21 @@
+"use client"
+
+import { useI18n, Lang } from "@/lib/i18n-context"
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
+
+export function LanguageSelector() {
+  const { lang, setLang } = useI18n()
+  return (
+    <Select value={lang} onValueChange={(value) => setLang(value as Lang)}>
+      <SelectTrigger className="w-28 sm:w-36">
+        <SelectValue />
+      </SelectTrigger>
+      <SelectContent>
+        <SelectItem value="pt">🇧🇷 Português</SelectItem>
+        <SelectItem value="en">🇺🇸 English</SelectItem>
+        <SelectItem value="es">🇪🇸 Español</SelectItem>
+      </SelectContent>
+    </Select>
+  )
+}
+

--- a/src/components/month-navigation.tsx
+++ b/src/components/month-navigation.tsx
@@ -3,12 +3,14 @@
 import { Button } from "@/components/ui/button"
 import { ChevronLeft, ChevronRight } from "lucide-react"
 import { useRouter, useSearchParams } from "next/navigation"
+import { useI18n } from "@/lib/i18n-context"
 
 interface MonthNavigationProps {
   currentMonth: string
 }
 
 export function MonthNavigation({ currentMonth }: MonthNavigationProps) {
+  const { t, lang } = useI18n()
   const router = useRouter()
   const searchParams = useSearchParams()
 
@@ -40,20 +42,21 @@ export function MonthNavigation({ currentMonth }: MonthNavigationProps) {
   const formatMonth = (monthStr: string) => {
     const [year, month] = monthStr.split("-")
     const date = new Date(Number.parseInt(year), Number.parseInt(month) - 1)
-    return date.toLocaleDateString("en-US", { month: "long", year: "numeric" })
+    const locale = lang === "pt" ? "pt-BR" : lang === "es" ? "es-ES" : "en-US"
+    return date.toLocaleDateString(locale, { month: "long", year: "numeric" })
   }
 
   return (
     <div className="flex items-center justify-between bg-white rounded-lg p-4 shadow-sm">
       <Button variant="outline" size="sm" onClick={() => navigateMonth("prev")} className="flex items-center gap-2">
         <ChevronLeft className="w-4 h-4" />
-        Previous
+        {t("monthNavigation.previous")}
       </Button>
 
       <h2 className="text-xl font-semibold text-slate-900">{formatMonth(currentMonth)}</h2>
 
       <Button variant="outline" size="sm" onClick={() => navigateMonth("next")} className="flex items-center gap-2">
-        Next
+        {t("monthNavigation.next")}
         <ChevronRight className="w-4 h-4" />
       </Button>
     </div>

--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -3,30 +3,34 @@
 import Link from "next/link"
 import { Button } from "@/components/ui/button"
 import { useAuth } from "@/lib/auth-context"
+import { useI18n } from "@/lib/i18n-context"
+import { LanguageSelector } from "@/components/language-selector"
 
 export function Navbar() {
   const { user, logout } = useAuth()
+  const { t } = useI18n()
   return (
     <header className="bg-white shadow-sm">
       <div className="max-w-7xl mx-auto px-4 py-3 flex justify-between items-center">
         <Link href="/" className="font-bold text-lg">
-          Budgetly
+          {t("app.name")}
         </Link>
         <nav className="flex items-center gap-2">
+          <LanguageSelector />
           {user ? (
             <>
-              <span className="text-sm text-slate-600">Hello, {user}</span>
+              <span className="text-sm text-slate-600">{t("navbar.hello")} {user}</span>
               <Button variant="outline" onClick={logout}>
-                Logout
+                {t("navbar.logout")}
               </Button>
             </>
           ) : (
             <>
               <Link href="/login">
-                <Button variant="ghost">Login</Button>
+                <Button variant="ghost">{t("navbar.login")}</Button>
               </Link>
               <Link href="/signup">
-                <Button>Sign Up</Button>
+                <Button>{t("navbar.signup")}</Button>
               </Link>
             </>
           )}

--- a/src/components/recent-transactions.tsx
+++ b/src/components/recent-transactions.tsx
@@ -1,12 +1,16 @@
+"use client"
+
 import { Badge } from "@/components/ui/badge"
 import type { Transaction } from "@/lib/types"
 import { TrendingUp, TrendingDown, DollarSign } from "lucide-react"
+import { useI18n } from "@/lib/i18n-context"
 
 interface RecentTransactionsProps {
   transactions: Transaction[]
 }
 
 export function RecentTransactions({ transactions }: RecentTransactionsProps) {
+  const { t, lang } = useI18n()
   const recentTransactions = transactions
     .sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime())
     .slice(0, 5)
@@ -38,16 +42,22 @@ export function RecentTransactions({ transactions }: RecentTransactionsProps) {
   }
 
   const formatCurrency = (amount: number) => {
-    return new Intl.NumberFormat("en-US", {
+    const locale = lang === "pt" ? "pt-BR" : lang === "es" ? "es-ES" : "en-US"
+    return new Intl.NumberFormat(locale, {
       style: "currency",
       currency: "USD",
     }).format(amount)
   }
 
+  const formatDate = (date: Date) => {
+    const locale = lang === "pt" ? "pt-BR" : lang === "es" ? "es-ES" : "en-US"
+    return new Date(date).toLocaleDateString(locale)
+  }
+
   if (recentTransactions.length === 0) {
     return (
       <div className="text-center py-8 text-slate-500">
-        No transactions yet. Add your first transaction to get started!
+        {t("recentTransactions.noTransactions")}
       </div>
     )
   }
@@ -62,9 +72,9 @@ export function RecentTransactions({ transactions }: RecentTransactionsProps) {
               <p className="font-medium text-slate-900">{transaction.description}</p>
               <div className="flex items-center gap-2 mt-1">
                 <Badge variant="secondary" className={getTypeColor(transaction.type)}>
-                  {transaction.type}
+                  {t(`type.${transaction.type}`)}
                 </Badge>
-                <span className="text-sm text-slate-500">{transaction.category}</span>
+                <span className="text-sm text-slate-500">{t(`category.${transaction.category}`)}</span>
               </div>
             </div>
           </div>
@@ -73,7 +83,7 @@ export function RecentTransactions({ transactions }: RecentTransactionsProps) {
               {transaction.type === "income" ? "+" : "-"}
               {formatCurrency(transaction.amount)}
             </p>
-            <p className="text-sm text-slate-500">{new Date(transaction.date).toLocaleDateString()}</p>
+            <p className="text-sm text-slate-500">{formatDate(transaction.date)}</p>
           </div>
         </div>
       ))}

--- a/src/components/transaction-list.tsx
+++ b/src/components/transaction-list.tsx
@@ -1,13 +1,17 @@
+"use client"
+
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import type { Transaction } from "@/lib/types"
 import { TrendingUp, TrendingDown, DollarSign, Trash2 } from "lucide-react"
+import { useI18n } from "@/lib/i18n-context"
 
 interface TransactionListProps {
   transactions: Transaction[]
 }
 
 export function TransactionList({ transactions }: TransactionListProps) {
+  const { t, lang } = useI18n()
   const getTypeIcon = (type: string) => {
     switch (type) {
       case "income":
@@ -35,10 +39,16 @@ export function TransactionList({ transactions }: TransactionListProps) {
   }
 
   const formatCurrency = (amount: number) => {
-    return new Intl.NumberFormat("en-US", {
+    const locale = lang === "pt" ? "pt-BR" : lang === "es" ? "es-ES" : "en-US"
+    return new Intl.NumberFormat(locale, {
       style: "currency",
       currency: "USD",
     }).format(amount)
+  }
+
+  const formatDate = (date: Date) => {
+    const locale = lang === "pt" ? "pt-BR" : lang === "es" ? "es-ES" : "en-US"
+    return new Date(date).toLocaleDateString(locale)
   }
 
   const sortedTransactions = transactions.sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime())
@@ -46,8 +56,8 @@ export function TransactionList({ transactions }: TransactionListProps) {
   if (transactions.length === 0) {
     return (
       <div className="text-center py-12 text-slate-500">
-        <p className="text-lg">No transactions found for this month.</p>
-        <p className="text-sm mt-2">Add your first transaction to get started!</p>
+        <p className="text-lg">{t("transactionList.noTransactions1")}</p>
+        <p className="text-sm mt-2">{t("transactionList.noTransactions2")}</p>
       </div>
     )
   }
@@ -66,17 +76,17 @@ export function TransactionList({ transactions }: TransactionListProps) {
                 <h3 className="font-medium text-slate-900">{transaction.description}</h3>
                 {transaction.isRecurring && (
                   <Badge variant="outline" className="text-xs">
-                    Recurring
+                    {t("transactionList.recurring")}
                   </Badge>
                 )}
               </div>
               <div className="flex items-center gap-2 text-sm text-slate-600">
                 <Badge variant="secondary" className={getTypeColor(transaction.type)}>
-                  {transaction.type}
+                  {t(`type.${transaction.type}`)}
                 </Badge>
-                <span>{transaction.category}</span>
+                <span>{t(`category.${transaction.category}`)}</span>
                 <span>•</span>
-                <span>{new Date(transaction.date).toLocaleDateString()}</span>
+                <span>{formatDate(transaction.date)}</span>
               </div>
             </div>
           </div>

--- a/src/lib/i18n-context.tsx
+++ b/src/lib/i18n-context.tsx
@@ -1,0 +1,286 @@
+"use client"
+
+import React, { createContext, useContext, useEffect, useState } from "react"
+
+export type Lang = "en" | "pt" | "es"
+
+interface I18nContextValue {
+  lang: Lang
+  setLang: (lang: Lang) => void
+  t: (key: string) => string
+}
+
+const translations: Record<Lang, Record<string, string>> = {
+  en: {
+    "app.name": "Budgetly",
+    "navbar.logout": "Logout",
+    "navbar.login": "Login",
+    "navbar.signup": "Sign Up",
+    "navbar.hello": "Hello,",
+    "common.loading": "Loading...",
+    "dashboard.title": "Finance Tracker",
+    "dashboard.subtitle": "Manage your monthly finances with ease",
+    "dashboard.addTransaction": "Add Transaction",
+    "dashboard.expenseBreakdown": "Expense Breakdown",
+    "dashboard.recentTransactions": "Recent Transactions",
+    "dashboard.quickActions": "Quick Actions",
+    "dashboard.addIncome": "Add Income",
+    "dashboard.addFixedExpense": "Add Fixed Expense",
+    "dashboard.addVariableExpense": "Add Variable Expense",
+    "monthNavigation.previous": "Previous",
+    "monthNavigation.next": "Next",
+    "financialSummary.totalIncome": "Total Income",
+    "financialSummary.fixedExpenses": "Fixed Expenses",
+    "financialSummary.variableExpenses": "Variable Expenses",
+    "financialSummary.netIncome": "Net Income",
+    "expenseChart.noExpenses": "No expenses recorded yet.",
+    "recentTransactions.noTransactions":
+      "No transactions yet. Add your first transaction to get started!",
+    "transactionList.noTransactions1":
+      "No transactions found for this month.",
+    "transactionList.noTransactions2":
+      "Add your first transaction to get started!",
+    "transactionList.recurring": "Recurring",
+    "type.income": "Income",
+    "type.fixed": "Fixed Expense",
+    "type.variable": "Variable Expense",
+    "addTransaction.headerTitle": "Add Transaction",
+    "addTransaction.headerSubtitle": "Record a new financial transaction",
+    "addTransaction.details": "Transaction Details",
+    "addTransaction.type": "Transaction Type",
+    "addTransaction.income": "Income",
+    "addTransaction.fixedExpense": "Fixed Expense",
+    "addTransaction.variableExpense": "Variable Expense",
+    "addTransaction.amount": "Amount ($)",
+    "addTransaction.description": "Description",
+    "addTransaction.enterDescription": "Enter transaction description",
+    "addTransaction.category": "Category",
+    "addTransaction.selectCategory": "Select a category",
+    "addTransaction.date": "Date",
+    "addTransaction.recurringTransaction": "Recurring Transaction",
+    "addTransaction.numberOfMonths": "Number of Months",
+    "addTransaction.save": "Save Transaction",
+    "transactionsPage.allTransactions": "All Transactions",
+    "transactionsPage.viewManage": "View and manage your transactions",
+    "transactionsPage.transactionsFor": "Transactions for",
+    "monthlyBudgetPage.title": "Monthly Budget",
+    "login.email": "Email",
+    "login.password": "Password",
+    "login.logIn": "Log In",
+    "login.noAccount": "Don't have an account?",
+    "login.signUp": "Sign Up",
+    "signup.signUp": "Sign Up",
+    "signup.haveAccount": "Already have an account?",
+    "signup.logIn": "Log In",
+    "category.Salary": "Salary",
+    "category.Freelance": "Freelance",
+    "category.Investment": "Investment",
+    "category.Other": "Other",
+    "category.Rent": "Rent",
+    "category.Insurance": "Insurance",
+    "category.Loan Payment": "Loan Payment",
+    "category.Subscription": "Subscription",
+    "category.Utilities": "Utilities",
+    "category.Food": "Food",
+    "category.Transportation": "Transportation",
+    "category.Entertainment": "Entertainment",
+    "category.Shopping": "Shopping",
+    "category.Healthcare": "Healthcare",
+  },
+  pt: {
+    "app.name": "Budgetly",
+    "navbar.logout": "Sair",
+    "navbar.login": "Entrar",
+    "navbar.signup": "Criar Conta",
+    "navbar.hello": "Olá,",
+    "common.loading": "Carregando...",
+    "dashboard.title": "Controle Financeiro",
+    "dashboard.subtitle": "Gerencie suas finanças mensais com facilidade",
+    "dashboard.addTransaction": "Adicionar Transação",
+    "dashboard.expenseBreakdown": "Distribuição de Despesas",
+    "dashboard.recentTransactions": "Transações Recentes",
+    "dashboard.quickActions": "Ações Rápidas",
+    "dashboard.addIncome": "Adicionar Receita",
+    "dashboard.addFixedExpense": "Adicionar Despesa Fixa",
+    "dashboard.addVariableExpense": "Adicionar Despesa Variável",
+    "monthNavigation.previous": "Anterior",
+    "monthNavigation.next": "Próximo",
+    "financialSummary.totalIncome": "Receita Total",
+    "financialSummary.fixedExpenses": "Despesas Fixas",
+    "financialSummary.variableExpenses": "Despesas Variáveis",
+    "financialSummary.netIncome": "Saldo",
+    "expenseChart.noExpenses": "Nenhuma despesa registrada.",
+    "recentTransactions.noTransactions":
+      "Nenhuma transação ainda. Adicione sua primeira transação para começar!",
+    "transactionList.noTransactions1":
+      "Nenhuma transação encontrada para este mês.",
+    "transactionList.noTransactions2":
+      "Adicione sua primeira transação para começar!",
+    "transactionList.recurring": "Recorrente",
+    "type.income": "Receita",
+    "type.fixed": "Despesa Fixa",
+    "type.variable": "Despesa Variável",
+    "addTransaction.headerTitle": "Adicionar Transação",
+    "addTransaction.headerSubtitle": "Registre uma nova transação financeira",
+    "addTransaction.details": "Detalhes da Transação",
+    "addTransaction.type": "Tipo de Transação",
+    "addTransaction.income": "Receita",
+    "addTransaction.fixedExpense": "Despesa Fixa",
+    "addTransaction.variableExpense": "Despesa Variável",
+    "addTransaction.amount": "Valor (R$)",
+    "addTransaction.description": "Descrição",
+    "addTransaction.enterDescription": "Digite a descrição",
+    "addTransaction.category": "Categoria",
+    "addTransaction.selectCategory": "Selecione uma categoria",
+    "addTransaction.date": "Data",
+    "addTransaction.recurringTransaction": "Transação Recorrente",
+    "addTransaction.numberOfMonths": "Número de Meses",
+    "addTransaction.save": "Salvar Transação",
+    "transactionsPage.allTransactions": "Todas as Transações",
+    "transactionsPage.viewManage": "Veja e gerencie suas transações",
+    "transactionsPage.transactionsFor": "Transações de",
+    "monthlyBudgetPage.title": "Orçamento Mensal",
+    "login.email": "Email",
+    "login.password": "Senha",
+    "login.logIn": "Entrar",
+    "login.noAccount": "Não possui conta?",
+    "login.signUp": "Cadastrar",
+    "signup.signUp": "Cadastrar",
+    "signup.haveAccount": "Já possui conta?",
+    "signup.logIn": "Entrar",
+    "category.Salary": "Salário",
+    "category.Freelance": "Freelance",
+    "category.Investment": "Investimento",
+    "category.Other": "Outro",
+    "category.Rent": "Aluguel",
+    "category.Insurance": "Seguro",
+    "category.Loan Payment": "Pagamento de Empréstimo",
+    "category.Subscription": "Assinatura",
+    "category.Utilities": "Serviços",
+    "category.Food": "Alimentação",
+    "category.Transportation": "Transporte",
+    "category.Entertainment": "Entretenimento",
+    "category.Shopping": "Compras",
+    "category.Healthcare": "Saúde",
+  },
+  es: {
+    "app.name": "Budgetly",
+    "navbar.logout": "Salir",
+    "navbar.login": "Iniciar Sesión",
+    "navbar.signup": "Registrarse",
+    "navbar.hello": "Hola,",
+    "common.loading": "Cargando...",
+    "dashboard.title": "Control Financiero",
+    "dashboard.subtitle": "Administra tus finanzas mensuales fácilmente",
+    "dashboard.addTransaction": "Agregar Transacción",
+    "dashboard.expenseBreakdown": "Distribución de Gastos",
+    "dashboard.recentTransactions": "Transacciones Recientes",
+    "dashboard.quickActions": "Acciones Rápidas",
+    "dashboard.addIncome": "Agregar Ingreso",
+    "dashboard.addFixedExpense": "Agregar Gasto Fijo",
+    "dashboard.addVariableExpense": "Agregar Gasto Variable",
+    "monthNavigation.previous": "Anterior",
+    "monthNavigation.next": "Siguiente",
+    "financialSummary.totalIncome": "Ingresos Totales",
+    "financialSummary.fixedExpenses": "Gastos Fijos",
+    "financialSummary.variableExpenses": "Gastos Variables",
+    "financialSummary.netIncome": "Saldo",
+    "expenseChart.noExpenses": "Aún no se registran gastos.",
+    "recentTransactions.noTransactions":
+      "No hay transacciones. ¡Agrega tu primera transacción para comenzar!",
+    "transactionList.noTransactions1":
+      "No se encontraron transacciones este mes.",
+    "transactionList.noTransactions2":
+      "¡Agrega tu primera transacción para comenzar!",
+    "transactionList.recurring": "Recurrente",
+    "type.income": "Ingreso",
+    "type.fixed": "Gasto Fijo",
+    "type.variable": "Gasto Variable",
+    "addTransaction.headerTitle": "Agregar Transacción",
+    "addTransaction.headerSubtitle": "Registra una nueva transacción financiera",
+    "addTransaction.details": "Detalles de la Transacción",
+    "addTransaction.type": "Tipo de Transacción",
+    "addTransaction.income": "Ingreso",
+    "addTransaction.fixedExpense": "Gasto Fijo",
+    "addTransaction.variableExpense": "Gasto Variable",
+    "addTransaction.amount": "Monto ($)",
+    "addTransaction.description": "Descripción",
+    "addTransaction.enterDescription": "Ingresa la descripción",
+    "addTransaction.category": "Categoría",
+    "addTransaction.selectCategory": "Seleccione una categoría",
+    "addTransaction.date": "Fecha",
+    "addTransaction.recurringTransaction": "Transacción Recurrente",
+    "addTransaction.numberOfMonths": "Número de Meses",
+    "addTransaction.save": "Guardar Transacción",
+    "transactionsPage.allTransactions": "Todas las Transacciones",
+    "transactionsPage.viewManage": "Ver y administrar tus transacciones",
+    "transactionsPage.transactionsFor": "Transacciones de",
+    "monthlyBudgetPage.title": "Presupuesto Mensual",
+    "login.email": "Correo",
+    "login.password": "Contraseña",
+    "login.logIn": "Iniciar Sesión",
+    "login.noAccount": "¿No tienes cuenta?",
+    "login.signUp": "Regístrate",
+    "signup.signUp": "Regístrate",
+    "signup.haveAccount": "¿Ya tienes cuenta?",
+    "signup.logIn": "Iniciar Sesión",
+    "category.Salary": "Salario",
+    "category.Freelance": "Freelance",
+    "category.Investment": "Inversión",
+    "category.Other": "Otro",
+    "category.Rent": "Alquiler",
+    "category.Insurance": "Seguro",
+    "category.Loan Payment": "Pago de Préstamo",
+    "category.Subscription": "Suscripción",
+    "category.Utilities": "Servicios",
+    "category.Food": "Alimentación",
+    "category.Transportation": "Transporte",
+    "category.Entertainment": "Entretenimiento",
+    "category.Shopping": "Compras",
+    "category.Healthcare": "Salud",
+  },
+}
+
+const I18nContext = createContext<I18nContextValue | undefined>(undefined)
+
+export function I18nProvider({ children }: { children: React.ReactNode }) {
+  const [lang, setLangState] = useState<Lang>("en")
+
+  useEffect(() => {
+    const stored = typeof window !== "undefined" ? (localStorage.getItem("lang") as Lang | null) : null
+    if (stored) {
+      setLangState(stored)
+      document.documentElement.lang = stored
+    } else if (typeof navigator !== "undefined") {
+      const navLang = navigator.language.slice(0, 2)
+      const detected = navLang === "pt" ? "pt" : navLang === "es" ? "es" : "en"
+      setLangState(detected)
+      document.documentElement.lang = detected
+    }
+  }, [])
+
+  const setLang = (l: Lang) => {
+    setLangState(l)
+    if (typeof window !== "undefined") {
+      localStorage.setItem("lang", l)
+    }
+    document.documentElement.lang = l
+  }
+
+  const t = (key: string) => {
+    return translations[lang][key] || translations.en[key] || key
+  }
+
+  return (
+    <I18nContext.Provider value={{ lang, setLang, t }}>
+      {children}
+    </I18nContext.Provider>
+  )
+}
+
+export function useI18n() {
+  const ctx = useContext(I18nContext)
+  if (!ctx) throw new Error("useI18n must be used within I18nProvider")
+  return ctx
+}
+


### PR DESCRIPTION
## Summary
- translate transaction type labels in the i18n dictionaries
- localize category names and dates in RecentTransactions and TransactionList

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843c30e5854832b97b2edac9310e9f8