### PR TITLE
Fix duplicate exports in pages

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -113,13 +113,3 @@ export default function Dashboard() {
     </div>
   )
 }
-
-export default function Dashboard() {
-  return (
-    <div className="min-h-screen bg-gradient-to-br from-slate-50 to-slate-100 p-4">
-      <Suspense fallback={<div className="p-4">Loading...</div>}>
-        <DashboardContent />
-      </Suspense>
-    </div>
-  )
-}

--- a/src/app/transactions/page.tsx
+++ b/src/app/transactions/page.tsx
@@ -67,13 +67,3 @@ export default function TransactionsPage() {
     </div>
   )
 }
-
-export default function TransactionsPage() {
-  return (
-    <div className="min-h-screen bg-gradient-to-br from-slate-50 to-slate-100 p-4">
-      <Suspense fallback={<div className="p-4">Loading...</div>}>
-        <TransactionsContent />
-      </Suspense>
-    </div>
-  )
-}


### PR DESCRIPTION
## Summary
- remove repeated `Dashboard` and `TransactionsPage` exports that broke builds

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684494be7ef8832b9690095e46a11b27