### PR TITLE
Improve transaction components mobile layout

### DIFF
--- a/src/components/recent-transactions.tsx
+++ b/src/components/recent-transactions.tsx
@@ -60,8 +60,11 @@ export function RecentTransactions({ transactions }: RecentTransactionsProps) {
   return (
     <div className="space-y-4">
       {recentTransactions.map((transaction) => (
-        <div key={transaction.id} className="flex items-center justify-between p-3 bg-slate-50 rounded-lg">
-          <div className="flex items-center gap-3">
+        <div
+          key={transaction.id}
+          className="flex flex-col sm:flex-row sm:items-center justify-between gap-2 p-3 bg-slate-50 rounded-lg"
+        >
+          <div className="flex items-start gap-3 flex-1">
             {getTypeIcon(transaction.type)}
             <div>
               <p className="font-medium text-slate-900">{transaction.description}</p>
@@ -73,7 +76,7 @@ export function RecentTransactions({ transactions }: RecentTransactionsProps) {
               </div>
             </div>
           </div>
-          <div className="text-right">
+          <div className="mt-2 sm:mt-0 text-right">
             <p className={`font-semibold ${transaction.type === "income" ? "text-green-600" : "text-red-600"}`}>
               {transaction.type === "income" ? "+" : "-"}
               {formatCurrency(transaction.amount)}

--- a/src/components/transaction-list.tsx
+++ b/src/components/transaction-list.tsx
@@ -63,9 +63,9 @@ export function TransactionList({ transactions }: TransactionListProps) {
       {sortedTransactions.map((transaction) => (
         <div
           key={transaction.id}
-          className="flex items-center justify-between p-4 bg-white border rounded-lg shadow-sm hover:shadow-md transition-shadow"
+          className="flex flex-col sm:flex-row justify-between gap-3 p-4 bg-white border rounded-lg shadow-sm hover:shadow-md transition-shadow"
         >
-          <div className="flex items-center gap-4">
+          <div className="flex items-start gap-4 flex-1">
             {getTypeIcon(transaction.type)}
             <div className="flex-1">
               <div className="flex items-center gap-2 mb-1">
@@ -86,7 +86,7 @@ export function TransactionList({ transactions }: TransactionListProps) {
               </div>
             </div>
           </div>
-          <div className="flex items-center gap-3">
+          <div className="flex items-center gap-3 sm:justify-end mt-2 sm:mt-0">
             <div className="text-right">
               <p
                 className={`text-lg font-semibold ${transaction.type === "income" ? "text-green-600" : "text-red-600"}`}


### PR DESCRIPTION
## Summary
- update `recent-transactions` layout for small screens
- update `transaction-list` layout for small screens

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844ce0595c4832ba3118d5c89b8d986