### PR TITLE
Add dark mode support

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -6,6 +6,7 @@ import { AuthProvider } from "@/lib/auth-context"
 import { I18nProvider } from "@/lib/i18n-context"
 import { CurrencyProvider } from "@/lib/currency-context"
 import { Navbar } from "@/components/navbar"
+import { DarkModeProvider } from "@/lib/dark-mode-context"
 
 const inter = Inter({ subsets: ["latin"] })
 
@@ -21,16 +22,18 @@ export default function RootLayout({
   children: React.ReactNode
 }) {
   return (
-    <html lang="en">
+    <html lang="en" suppressHydrationWarning>
       <body className={inter.className}>
-        <I18nProvider>
-          <CurrencyProvider>
-            <AuthProvider>
-              <Navbar />
-              {children}
-            </AuthProvider>
-          </CurrencyProvider>
-        </I18nProvider>
+        <DarkModeProvider>
+          <I18nProvider>
+            <CurrencyProvider>
+              <AuthProvider>
+                <Navbar />
+                {children}
+              </AuthProvider>
+            </CurrencyProvider>
+          </I18nProvider>
+        </DarkModeProvider>
       </body>
     </html>
   )

--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -9,13 +9,14 @@ import { useAuth } from "@/lib/auth-context"
 import { useI18n } from "@/lib/i18n-context"
 import { LanguageSelector } from "@/components/language-selector"
 import { CurrencySelector } from "@/components/currency-selector"
+import { ThemeToggle } from "@/components/theme-toggle"
 
 export function Navbar() {
   const { user, logout } = useAuth()
   const { t } = useI18n()
   const [open, setOpen] = useState(false)
   return (
-    <header className="bg-white shadow-sm">
+    <header className="bg-white dark:bg-slate-800 shadow-sm">
       <div className="max-w-7xl mx-auto px-4 py-3 relative flex items-center justify-between">
         <button
           className="sm:hidden"
@@ -26,16 +27,17 @@ export function Navbar() {
         </button>
         <Link
           href="/"
-          className="font-bold text-lg absolute left-1/2 -translate-x-1/2 sm:static sm:translate-x-0"
+          className="font-bold text-lg absolute left-1/2 -translate-x-1/2 sm:static sm:translate-x-0 text-slate-900 dark:text-slate-100"
         >
           {t("app.name")}
         </Link>
         <nav className="hidden sm:flex items-center gap-2">
           <LanguageSelector />
           <CurrencySelector />
+          <ThemeToggle />
           {user ? (
             <>
-              <span className="text-sm text-slate-600">{t("navbar.hello")} {user}</span>
+              <span className="text-sm text-slate-600 dark:text-slate-300">{t("navbar.hello")} {user}</span>
               <Button variant="outline" onClick={logout}>
                 {t("navbar.logout")}
               </Button>
@@ -55,7 +57,7 @@ export function Navbar() {
       {open && (
         <div className="fixed inset-0 z-50 flex">
           <div className="absolute inset-0 bg-black/50" onClick={() => setOpen(false)} />
-          <div className="relative z-10 w-64 h-full bg-white shadow-xl p-4 flex flex-col">
+          <div className="relative z-10 w-64 h-full bg-white dark:bg-slate-800 shadow-xl p-4 flex flex-col">
             <button
               className="self-end mb-4"
               onClick={() => setOpen(false)}
@@ -66,9 +68,10 @@ export function Navbar() {
             <div className="space-y-4">
               <LanguageSelector />
               <CurrencySelector />
+              <ThemeToggle />
               {user ? (
                 <>
-                  <span className="text-sm text-slate-600">{t("navbar.hello")} {user}</span>
+                  <span className="text-sm text-slate-600 dark:text-slate-300">{t("navbar.hello")} {user}</span>
                   <Button variant="outline" onClick={logout} className="w-full justify-start">
                     {t("navbar.logout")}
                   </Button>

--- a/src/components/theme-toggle.tsx
+++ b/src/components/theme-toggle.tsx
@@ -1,0 +1,20 @@
+"use client"
+
+import { Moon, Sun } from "lucide-react"
+import { useDarkMode } from "@/lib/dark-mode-context"
+import { Button } from "@/components/ui/button"
+
+export function ThemeToggle() {
+  const { isDark, toggle } = useDarkMode()
+  return (
+    <Button
+      variant="ghost"
+      size="icon"
+      onClick={toggle}
+      aria-label="Toggle dark mode"
+      className="w-9 h-9"
+    >
+      {isDark ? <Sun className="size-4" /> : <Moon className="size-4" />}
+    </Button>
+  )
+}

--- a/src/lib/dark-mode-context.tsx
+++ b/src/lib/dark-mode-context.tsx
@@ -1,0 +1,51 @@
+'use client'
+import { createContext, useContext, useEffect, useState } from 'react'
+
+interface DarkModeContextValue {
+  isDark: boolean
+  toggle: () => void
+}
+
+const DarkModeContext = createContext<DarkModeContextValue | undefined>(undefined)
+
+export function DarkModeProvider({ children }: { children: React.ReactNode }) {
+  const [isDark, setIsDark] = useState(false)
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+    const stored = localStorage.getItem('theme')
+    if (stored === 'dark') {
+      setIsDark(true)
+    } else if (stored === 'light') {
+      setIsDark(false)
+    } else {
+      setIsDark(window.matchMedia('(prefers-color-scheme: dark)').matches)
+    }
+  }, [])
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+    const root = document.documentElement
+    if (isDark) {
+      root.classList.add('dark')
+      localStorage.setItem('theme', 'dark')
+    } else {
+      root.classList.remove('dark')
+      localStorage.setItem('theme', 'light')
+    }
+  }, [isDark])
+
+  const toggle = () => setIsDark((prev) => !prev)
+
+  return (
+    <DarkModeContext.Provider value={{ isDark, toggle }}>
+      {children}
+    </DarkModeContext.Provider>
+  )
+}
+
+export function useDarkMode() {
+  const ctx = useContext(DarkModeContext)
+  if (!ctx) throw new Error('useDarkMode must be used within DarkModeProvider')
+  return ctx
+}


### PR DESCRIPTION
## Summary
- add dark mode provider and hook
- add theme toggle button
- wire dark mode provider in layout
- style navbar for dark mode and include toggle

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68478007c218832b868b5ce29b7022c0