### PR TITLE
Fix header button width on small screens

### DIFF
--- a/src/app/annual-overview/page.tsx
+++ b/src/app/annual-overview/page.tsx
@@ -39,6 +39,7 @@ function OverviewContent() {
           variant={currentView === "transactions" ? "default" : "outline"}
           size="sm"
           onClick={() => setView("transactions")}
+          className="w-full sm:w-auto"
         >
           {t("overviewCalendar.viewTransactions")}
         </Button>
@@ -46,6 +47,7 @@ function OverviewContent() {
           variant={currentView === "daily" ? "default" : "outline"}
           size="sm"
           onClick={() => setView("daily")}
+          className="w-full sm:w-auto"
         >
           {t("overviewCalendar.viewDaily")}
         </Button>
@@ -53,6 +55,7 @@ function OverviewContent() {
           variant={currentView === "annual" ? "default" : "outline"}
           size="sm"
           onClick={() => setView("annual")}
+          className="w-full sm:w-auto"
         >
           {t("overviewCalendar.viewAnnual")}
         </Button>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -29,13 +29,16 @@ function DashboardContent() {
           </div>
           <div className="flex flex-col sm:flex-row gap-2">
             <Link href="/transactions">
-              <Button variant="outline" className="flex items-center gap-2">
+              <Button
+                variant="outline"
+                className="w-full sm:w-auto flex items-center gap-2"
+              >
                 <Pencil className="w-4 h-4" />
                 {t("dashboard.editTransactions")}
               </Button>
             </Link>
             <Link href="/add-transaction">
-              <Button className="flex items-center gap-2">
+              <Button className="w-full sm:w-auto flex items-center gap-2">
                 <Plus className="w-4 h-4" />
                 {t("dashboard.addTransaction")}
               </Button>


### PR DESCRIPTION
## Summary
- ensure dashboard header actions stretch full-width on narrow screens
- make yearly overview view selectors full-width in column layout

## Testing
- `npm run lint` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6855de5a6124832b9a39cb8a0ee4606a